### PR TITLE
[script] fix docker image name

### DIFF
--- a/script/start-service.sh
+++ b/script/start-service.sh
@@ -44,4 +44,4 @@ sudo docker run -dt --privileged \
     --network $NETWORK --ip6 $IP6_ADDR \
     --sysctl 'net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1' \
     -v $ROOT_DIR:/home/ot-registrar \
-    ubuntu:java8-registrar
+    ubuntu:ot-registrar


### PR DESCRIPTION
This PR replaces stale docker image name `ubuntu:java8-registrar` with `ubuntu:ot-registrar`.