### PR TITLE
[logging] upgrade log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,11 @@
       <version>2.8.5</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/log4j/log4j -->
+    <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.16.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fixes the log4j security vulnerabilities: https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046