### PR TITLE
[logging] upgrade log4j to version 2.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
log4j 2.17.0 fixes new security vulnerabilities: https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45105